### PR TITLE
Fixed some crash fixes with twitch emote detection and message subtitation menu

### DIFF
--- a/Database/MessageSubstitution.cs
+++ b/Database/MessageSubstitution.cs
@@ -14,7 +14,7 @@ namespace TTS_Chan.Database
 
         public static string PerformAll(string source)
         {
-            var substitutions = DatabaseManager.Context.MessageSubstitutions.Where(ms => ms.IsEnabled && ms.Pattern != "").ToList();
+            var substitutions = DatabaseManager.Context.MessageSubstitutions.Where(ms => ms.IsEnabled && ms.Pattern != null).ToList();
             foreach (var messageSubstitution in substitutions.TakeWhile(_ => source.Length != 0))
             {
                 source = messageSubstitution.IsRegex ? Regex.Replace(source, messageSubstitution.Pattern, messageSubstitution.Replacement) : source.Replace(messageSubstitution.Pattern, messageSubstitution.Replacement);

--- a/DatabaseWindow.xaml
+++ b/DatabaseWindow.xaml
@@ -75,7 +75,7 @@
                             <RowDefinition Height="Auto"></RowDefinition>
                             <RowDefinition Height="*"></RowDefinition>
                         </Grid.RowDefinitions>
-                        <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Vertical" Grid.ColumnSpan="2">
                             <StackPanel Orientation="Vertical" Visibility="Collapsed" x:Name="SubtitutionHelpText">
                                 <TextBlock Text="The grid bellow represents rule based replacements for text in messages.&#x0a;You can define rules using Regular Expressions (consult interactive tool bellow)&#x0a;Click on an empty cell to a a new value. Press delete while having a cell selected to remove it.&#x0a;Results save automatically after you close the window"/>
                                 <TextBlock Margin="4,0,4,0">
@@ -83,25 +83,17 @@
                                 </TextBlock>
                             </StackPanel>
                             <Grid>
-                                <Button x:Name="PopulateButton" Padding="0" HorizontalAlignment="Left" Click="PopulateButton_Click" Height="40">
-                                    <Grid Height="40">
-                                        <TextBlock Text="Populate with useful values"
-                                                   VerticalAlignment="Center" HorizontalAlignment="Center"
-                                                   Padding="5,0,5,0"/>
-                                        <ToggleButton x:Name="HelpButton"
-                                                    Width="12" Height="12"
-                                                    Margin="0,1,1,0"
-                                                    HorizontalAlignment="Right"
-                                                    VerticalAlignment="Top"
-                                                    Style="{StaticResource MaterialDesignFloatingActionMiniAccentButton}"
-                                                    ToolTip="Import from speechchat"
-                                                    Content="{materialDesign:PackIcon Kind=Help, Size=8}" 
-                                                    Click="SubtitutionHelpInfo_Click"/>
-                                    </Grid>
-                                </Button>
+                                <Button x:Name="PopulateButton" Padding="5,0,5,0" Content="Populate with useful values" HorizontalAlignment="Left" Click="PopulateButton_Click" Height="40"/>
+                                <ToggleButton x:Name="HelpButton"
+                                                        HorizontalAlignment="Right"
+                                                        Margin="0,0,21,0"
+                                                        Style="{StaticResource MaterialDesignFloatingActionMiniAccentButton}"
+                                                        ToolTip="Import from speechchat"
+                                                        Content="{materialDesign:PackIcon Kind=Help, Size=30}" 
+                                                        Click="SubtitutionHelpInfo_Click" Background="#FF575B4C" BorderBrush="#FF757574" Foreground="White"/>
                             </Grid>
                         </StackPanel>
-                        <DataGrid x:Name="SubstitutionsGrid" Grid.Row="1" ItemsSource="{Binding}" AutoGenerateColumns="False" EnableRowVirtualization="True">
+                        <DataGrid x:Name="SubstitutionsGrid" Grid.Row="1" ItemsSource="{Binding}" AutoGenerateColumns="False" EnableRowVirtualization="True" Grid.ColumnSpan="2">
                             <DataGrid.Columns>
                                 <DataGridCheckBoxColumn ElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnStyle}"
                                                         EditingElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnEditingStyle}"

--- a/DatabaseWindow.xaml
+++ b/DatabaseWindow.xaml
@@ -26,8 +26,8 @@
                     </TabItem.Header>
                     <Grid>
                         <Grid.RowDefinitions>
-                                <RowDefinition Height="*" />
-                                <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <DataGrid x:Name="UsersGrid" Grid.Row="0" ItemsSource="{Binding}" AutoGenerateColumns="False" EnableRowVirtualization="False" CanUserAddRows="False" SelectionMode="Single" PreviewKeyDown="UsersGrid_PreviewKeyDown">
                             <DataGrid.Columns>
@@ -76,11 +76,30 @@
                             <RowDefinition Height="*"></RowDefinition>
                         </Grid.RowDefinitions>
                         <StackPanel Orientation="Vertical">
-                            <TextBlock Text="The grid bellow represents rule based replacements for text in messages.&#x0a;You can define rules using Regular Expressions (consult interactive tool bellow)&#x0a;Click on an empty cell to a a new value. Press delete while having a cell selected to remove it.&#x0a;Results save automatically after you close the window"/>
-                            <TextBlock Margin="4,0,4,0">
+                            <StackPanel Orientation="Vertical" Visibility="Collapsed" x:Name="SubtitutionHelpText">
+                                <TextBlock Text="The grid bellow represents rule based replacements for text in messages.&#x0a;You can define rules using Regular Expressions (consult interactive tool bellow)&#x0a;Click on an empty cell to a a new value. Press delete while having a cell selected to remove it.&#x0a;Results save automatically after you close the window"/>
+                                <TextBlock Margin="4,0,4,0">
                                 <Hyperlink NavigateUri="https://regex101.com/r/RHiPsL/1" RequestNavigate="Hyperlink_OnRequestNavigate">Interactive tool</Hyperlink>
-                            </TextBlock>
-                            <Button x:Name="PopulateButton" Width="auto" HorizontalAlignment="Left" VerticalAlignment="Bottom" Content="Populate with useful values" Margin="0,6,0,4" Click="PopulateButton_Click"/>
+                                </TextBlock>
+                            </StackPanel>
+                            <Grid>
+                                <Button x:Name="PopulateButton" Padding="0" HorizontalAlignment="Left" Click="PopulateButton_Click" Height="40">
+                                    <Grid Height="40">
+                                        <TextBlock Text="Populate with useful values"
+                                                   VerticalAlignment="Center" HorizontalAlignment="Center"
+                                                   Padding="5,0,5,0"/>
+                                        <ToggleButton x:Name="HelpButton"
+                                                    Width="12" Height="12"
+                                                    Margin="0,1,1,0"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Top"
+                                                    Style="{StaticResource MaterialDesignFloatingActionMiniAccentButton}"
+                                                    ToolTip="Import from speechchat"
+                                                    Content="{materialDesign:PackIcon Kind=Help, Size=8}" 
+                                                    Click="SubtitutionHelpInfo_Click"/>
+                                    </Grid>
+                                </Button>
+                            </Grid>
                         </StackPanel>
                         <DataGrid x:Name="SubstitutionsGrid" Grid.Row="1" ItemsSource="{Binding}" AutoGenerateColumns="False" EnableRowVirtualization="True">
                             <DataGrid.Columns>

--- a/DatabaseWindow.xaml.cs
+++ b/DatabaseWindow.xaml.cs
@@ -129,5 +129,17 @@ namespace TTS_Chan
             DatabaseManager.Context.UserVoices.Load();
             UsersGrid.DataContext = DatabaseManager.Context.UserVoices.Local.ToObservableCollection();
         }
+
+        private void SubtitutionHelpInfo_Click(object sender, RoutedEventArgs e)
+        {
+            e.Handled= true;
+            if (SubtitutionHelpText.Visibility == Visibility.Collapsed)
+            {
+                SubtitutionHelpText.Visibility = Visibility.Visible;
+            }
+            else {
+                SubtitutionHelpText.Visibility = Visibility.Collapsed;
+            }
+        }
     }
 }

--- a/DatabaseWindow.xaml.cs
+++ b/DatabaseWindow.xaml.cs
@@ -91,7 +91,7 @@ namespace TTS_Chan
 
         private void Window_Closed(object sender, System.EventArgs e)
         {
-            foreach (var ms in DatabaseManager.Context.MessageSubstitutions.Where(ms => ms.Pattern == ""))
+            foreach (var ms in DatabaseManager.Context.MessageSubstitutions.Local.Where(ms => ms.Pattern == null))
             {
                 DatabaseManager.Context.MessageSubstitutions.Remove(ms);
             }

--- a/DatabaseWindow.xaml.cs
+++ b/DatabaseWindow.xaml.cs
@@ -132,7 +132,6 @@ namespace TTS_Chan
 
         private void SubtitutionHelpInfo_Click(object sender, RoutedEventArgs e)
         {
-            e.Handled= true;
             if (SubtitutionHelpText.Visibility == Visibility.Collapsed)
             {
                 SubtitutionHelpText.Visibility = Visibility.Visible;

--- a/Twitch/TwitchMessage.cs
+++ b/Twitch/TwitchMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using TTS_Chan.Database;
 
@@ -103,9 +104,10 @@ namespace TTS_Chan.Twitch
             var text = Text;
             if (Properties.Settings.Default.DisableTwitchEmotes && Tags.ContainsKey("emotes") && Tags["emotes"] != "")
             {
-                var matches = Regex.Matches(Tags["emotes"], @"(?<emote>\w+):(?<start>\d+)-(?<end>\d+)");
+                var matches = Regex.Matches(Tags["emotes"], @"(?<start>\d+)-(?<end>\d+)");
                 var emoteOffset = 0;
-                foreach (Match match in matches)
+                List<Match> sortedMatches = matches.OrderBy(match => int.Parse(match.Groups["start"].Value)).ToList<Match>();
+                foreach (Match match in sortedMatches)
                 {
                     var start = int.Parse(match.Groups["start"].Value);
                     var end = int.Parse(match.Groups["end"].Value);


### PR DESCRIPTION
- Subtitutions crashed if person made extra empty field which is pretty easy by accident. Now corrently remove it before saving to database.
- moved subtition info behind button. wish i knew more xaml, i would have put it on top right corner on top of the tab button.
- Fixed crash that was caused by twitch incompetent emote id naming. It was either int-int:ID or ID:int-int. Old regex could not find all emotes because of this and in some cases the emotes were sorted incorrectly causing the emoteoffset to go out of bounds.

